### PR TITLE
#13: Update `create-tag` to use `GITHUB_TOKEN` instead of a PAT.

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -9,13 +9,15 @@ on:
 
 jobs:
   Create-Release-Tag:
+    permissions:
+      contents: write
     if: github.event.pull_request.merged
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.ACTION_CREATE_TAG_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Get Latest Tag'
       id: get-latest-tag
       run: |


### PR DESCRIPTION
Resolves #13.